### PR TITLE
✨ feat(workflows): enhanced source build workflow for dependency managment

### DIFF
--- a/.github/workflows/reusable-source-build.yaml
+++ b/.github/workflows/reusable-source-build.yaml
@@ -1,6 +1,5 @@
 name: Reusable Source Build
 # Reusable GitHub Actions workflow to build all ROS 2 packages from source
-
 on:
   workflow_call:
     inputs:
@@ -32,8 +31,13 @@ on:
       gcc_version:
         description: "GCC version to install"
         required: false
-        default: "11"
+        default: "11" # Default GCC version commonly available on Ubuntu 22.04
         type: string
+      download_requirements:
+        description: "Download and execute requirements.sh if available"
+        required: false
+        default: false
+        type: boolean
 jobs:
   build:
     runs-on: ${{ inputs.os_name }}
@@ -50,6 +54,23 @@ jobs:
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
+      # Check out the repository to get access to requirements.sh if required
+      - name: Check out the repository
+        if: inputs.download_requirements
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      # Conditionally download and execute requirements.sh if download_requirements is true and file exists
+      - name: Download and install extra dependencies if requirements.sh exists
+        if: inputs.download_requirements
+        run: |
+          if [ -f requirements.sh ]; then
+            echo "Executing requirements.sh from repository root directory"
+            chmod +x requirements.sh
+            ./requirements.sh
+          else
+            echo "requirements.sh file not found in repository root"
+          fi
       - name: build and test ROS 2 packages
         uses: ros-tooling/action-ros-ci@v0.3
         with:


### PR DESCRIPTION
Source build workflow now supports the repo having a bash script, needs to be called requirements.sh, which can be used to install dependencies, in addition to those installed using rosdep. This is needed in case a dependency is not supported by rosdep.