### PR TITLE
ci: update simulator-test workflow to use PR branch of caller repo

### DIFF
--- a/.github/workflows/reusable-ros2-simulator-test.yml
+++ b/.github/workflows/reusable-ros2-simulator-test.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          path: ros2_ws/src/${{ github.event.repository.name }}
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.14
         with:

--- a/.github/workflows/reusable-ros2-simulator-test.yml
+++ b/.github/workflows/reusable-ros2-simulator-test.yml
@@ -33,8 +33,8 @@ jobs:
     container:
       image: ros:${{ inputs.ros_distro }}-ros-base
     env:
-      WORKSPACE: ~/ros2_ws
-      CALLER_REPO: ~/ros2_ws/src/${{ github.event.repository.name }}
+      WORKSPACE: ${{ github.workspace }}/ros2_ws
+      CALLER_REPO: ${{ github.workspace }}/ros2_ws/src/${{ github.event.repository.name }}
 
     steps:
       - name: Checkout caller repository (PR code)
@@ -50,11 +50,11 @@ jobs:
       - name: Import dependencies from .repos file
         if: inputs.vcs_repos_file != ''
         run: |
-          mkdir -p ~/ros2_ws/src
+          mkdir -p $WORKSPACE/src
           if [ -f "$CALLER_REPO/${{ inputs.vcs_repos_file }}" ]; then
-            vcs import ~/ros2_ws/src < "$CALLER_REPO/${{ inputs.vcs_repos_file }}"
+            vcs import $WORKSPACE/src < "$CALLER_REPO/${{ inputs.vcs_repos_file }}"
             rosdep update
-            rosdep install --from-paths ~/ros2_ws/src --ignore-src -r -y
+            rosdep install --from-paths $WORKSPACE/src --ignore-src -r -y
           else
             echo "Provided .repos file does not exist: $CALLER_REPO/${{ inputs.vcs_repos_file }}"
           fi
@@ -83,4 +83,4 @@ jobs:
         if: failure()
         with:
           name: colcon-logs
-          path: ~/ros2_ws/log
+          path: ${{ github.workspace }}/ros2_ws/log

--- a/.github/workflows/reusable-ros2-simulator-test.yml
+++ b/.github/workflows/reusable-ros2-simulator-test.yml
@@ -26,7 +26,6 @@ on:
         description: "Path to the test script to execute (relative to caller repo)"
         required: true
         type: string
-
 jobs:
   build-and-test:
     runs-on: ${{ inputs.os }}
@@ -35,18 +34,15 @@ jobs:
     env:
       WORKSPACE: ${{ github.workspace }}/ros2_ws
       CALLER_REPO: ${{ github.workspace }}/ros2_ws/src/${{ github.event.repository.name }}
-
     steps:
       - name: Checkout caller repository (PR code)
         uses: actions/checkout@v4
         with:
           path: ros2_ws/src/${{ github.event.repository.name }}
-
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.14
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
-
       - name: Import dependencies from .repos file
         if: inputs.vcs_repos_file != ''
         run: |
@@ -58,7 +54,6 @@ jobs:
           else
             echo "Provided .repos file does not exist: $CALLER_REPO/${{ inputs.vcs_repos_file }}"
           fi
-
       - name: Run setup script
         if: inputs.setup_script != ''
         run: |
@@ -68,7 +63,6 @@ jobs:
           else
             echo "Provided script does not exist: $CALLER_REPO/${{ inputs.setup_script }}"
           fi
-
       - name: Run test script
         if: inputs.test_script != ''
         run: |
@@ -78,7 +72,6 @@ jobs:
           else
             echo "Provided script does not exist: $CALLER_REPO/${{ inputs.test_script }}"
           fi
-
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/reusable-ros2-simulator-test.yml
+++ b/.github/workflows/reusable-ros2-simulator-test.yml
@@ -13,19 +13,20 @@ on:
         default: "humble"
         type: string
       vcs_repos_file:
-        description: "Path to the .repos file for dependencies"
+        description: "Path to the .repos file for dependencies (relative to caller repo)"
         required: false
         default: "*.repos"
         type: string
       setup_script:
-        description: "Path to the setup script to execute"
+        description: "Path to the setup script to execute (relative to caller repo)"
         required: false
         default: ""
         type: string
       test_script:
-        description: "Path to the test script to execute"
+        description: "Path to the test script to execute (relative to caller repo)"
         required: true
         type: string
+
 jobs:
   build-and-test:
     runs-on: ${{ inputs.os }}
@@ -33,42 +34,53 @@ jobs:
       image: ros:${{ inputs.ros_distro }}-ros-base
     env:
       WORKSPACE: ~/ros2_ws
+      CALLER_REPO: ~/ros2_ws/src/${{ github.event.repository.name }}
+
     steps:
-      - name: Checkout repository
+      - name: Checkout caller repository (PR code)
         uses: actions/checkout@v4
         with:
           path: ros2_ws/src/${{ github.event.repository.name }}
+
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.14
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
+
       - name: Import dependencies from .repos file
         if: inputs.vcs_repos_file != ''
         run: |
           mkdir -p ~/ros2_ws/src
-          vcs import ~/ros2_ws/src < ${{ inputs.vcs_repos_file }}
-          rosdep update
-          rosdep install --from-paths ~/ros2_ws/src --ignore-src -r -y
+          if [ -f "$CALLER_REPO/${{ inputs.vcs_repos_file }}" ]; then
+            vcs import ~/ros2_ws/src < "$CALLER_REPO/${{ inputs.vcs_repos_file }}"
+            rosdep update
+            rosdep install --from-paths ~/ros2_ws/src --ignore-src -r -y
+          else
+            echo "Provided .repos file does not exist: $CALLER_REPO/${{ inputs.vcs_repos_file }}"
+          fi
+
       - name: Run setup script
         if: inputs.setup_script != ''
         run: |
-          if [ -f "${{ inputs.setup_script }}" ]; then
-            chmod +x "${{ inputs.setup_script }}"
-            "${{ inputs.setup_script }}"
+          if [ -f "$CALLER_REPO/${{ inputs.setup_script }}" ]; then
+            chmod +x "$CALLER_REPO/${{ inputs.setup_script }}"
+            "$CALLER_REPO/${{ inputs.setup_script }}"
           else
-            echo "Provided script does not exist: ${{ inputs.setup_script }}"
+            echo "Provided script does not exist: $CALLER_REPO/${{ inputs.setup_script }}"
           fi
+
       - name: Run test script
         if: inputs.test_script != ''
         run: |
-          if [ -f "${{ inputs.test_script }}" ]; then
-            chmod +x "${{ inputs.test_script }}"
-            "${{ inputs.test_script }}"
+          if [ -f "$CALLER_REPO/${{ inputs.test_script }}" ]; then
+            chmod +x "$CALLER_REPO/${{ inputs.test_script }}"
+            "$CALLER_REPO/${{ inputs.test_script }}"
           else
-            echo "Provided script does not exist: ${{ inputs.test_script }}"
+            echo "Provided script does not exist: $CALLER_REPO/${{ inputs.test_script }}"
           fi
+
       - uses: actions/upload-artifact@v4
+        if: failure()
         with:
           name: colcon-logs
           path: ~/ros2_ws/log
-        if: failure()


### PR DESCRIPTION
This PR updates the `reusable-ros2-simulator-test.yml` workflow:
- Caller repository (the one triggering the workflow) is now checked out into `ros2_ws/src/<repo>` so its PR branch is tested.
- Paths for `.repos`, setup script, and test scripts are resolved relative to the caller repo.
- Added timeout (1h) to prevent jobs from hanging indefinitely.

This ensures simulator tests run against the code from the pull request, while all other dependencies still come from main.